### PR TITLE
Add sgte.app.src to allow rebar to use as dependency

### DIFF
--- a/src/sgte.app.src
+++ b/src/sgte.app.src
@@ -1,0 +1,8 @@
+{application, sgte, [
+    {description, "StringTemplate"},
+    {vsn, "0.1"},
+    {modules, []},
+    {registered, []},
+    {applications, [kernel, stdlib]},
+    {env, []}
+]}.


### PR DESCRIPTION
Hi,

I added sgte.app.src, which allows rebar to use the project as a dependency.

Thanks
Knut
